### PR TITLE
Add timestamped metrics and lables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea/
 metrics.proto
 vendor

--- a/src/Client.php
+++ b/src/Client.php
@@ -5,6 +5,7 @@ class Client {
 	private $registry;
 	private $options;
 	private $base_uri;
+	private $labels;
 
 	public function __construct(array $options = []) {
 		$this->registry = new Registry;
@@ -59,6 +60,10 @@ class Client {
 		if($job) $url.=$job;
 		if($instance) $url.="/instance/".$instance;
 
+		foreach($this->labels as $label => $labelValue) {
+			$url.=('/' . urlencode($label) . '/' . urlencode($labelValue));
+		}
+
 		$ch = \curl_init($url);
 
 		\curl_setopt( $ch, CURLOPT_RETURNTRANSFER, TRUE );
@@ -72,6 +77,11 @@ class Client {
 
 		#TODO: Can the pushgateway return a 200 on successful PUT?
 		# Currently it returns nothing no matter what, lame
+	}
+
+	public function setLabels(array $labels)
+	{
+		$this->labels = $labels;
 	}
 }
 

--- a/src/Metric.php
+++ b/src/Metric.php
@@ -14,12 +14,15 @@ abstract class Metric {
 
 	public $full_name;
 
+	public $timestamped = false;
+
 	public function __construct(array $opts = []) {
 		$this->opts = $opts;
 		$this->name = isset($opts['name']) ? $opts['name'] : '';
 		$this->namespace = isset($opts['namespace']) ? $opts['namespace'] : '';
 		$this->subsystem = isset($opts['subsystem']) ? $opts['subsystem'] : '';
 		$this->help = isset($opts['help']) ? $opts['help'] : '';
+		$this->timestamped = isset($opts['timestamped']) ? (bool)$opts['timestamped'] : '';
 
 		if (empty($this->name)) throw new PrometheusException("A name is required for a metric");
 		if (empty($this->help)) throw new PrometheusException("A help is required for a metric");
@@ -66,7 +69,7 @@ abstract class Metric {
 				$v = str_replace("\\", "\\\\", $v);
 				$label_pairs []= "$k=\"$v\"";
 			}
-			$tbr []= $this->full_name . $suffix . "{" . implode(",", $label_pairs) . "} " . $value;
+			$tbr []= $this->full_name . $suffix . "{" . implode(",", $label_pairs) . "} " . $value . ($this->timestamped ? (' ' . time() . '000') : '');
 		}
 		return implode("\n", $tbr);
 	}


### PR DESCRIPTION
I've added the functionality to send the timestamp with the metric on push. This feature is activated trough the `timestamped` option of the metric.

The second feature is used to push the metrics with defined labels (besides job name and instance) to be able not to overwrite the last push. This is the only solution i've found to solve the problems when the push happens more often than the scraping.
