### PR TITLE
Move to php 7.1 & cleanup & clean metrics array after push

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Creating a new client is easy.  Since the PHP client lives in the Prometheus nam
 a new client.  In addition the client must be passed a list of options.  Currently the only valid option is 'base_uri'.
 If you don't plan on using the built in "pushMetrics" function, you may set this to an empty string.
 ```php
-$client = new Prometheus\Client(['base_uri' => 'http://localhost:9091/metrics/job/']);
+$client = new Prometheus\Client('http://localhost:9091/metrics/job/');
 ```
 
 Next we tell the client to create a new metric.  Here we are creating a new *Counter*.
@@ -111,7 +111,7 @@ Here is the above code all in one snippet.
 ```php
 	require_once dirname(__FILE__) . '/../src/Client.php';
 
-	$client = new Prometheus\Client(['base_uri' => 'http://localhost:9091/metrics/job/']);
+	$client = new Prometheus\Client('http://localhost:9091/metrics/job/');
 
 	$counter = $client->newCounter([
 		'namespace' => 'php_client',

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,9 @@
 			"email": "lazyshot@gmail.com"
 		}
 	],
+	"require": {
+		"php": "^7.1"
+	},
 	"autoload": {
 		"psr-4": {
 			"Prometheus\\": "src/"

--- a/src/Client.php
+++ b/src/Client.php
@@ -1,42 +1,51 @@
 <?php
+
 namespace Prometheus;
 
-class Client {
+class Client
+{
 	private $registry;
-	private $options;
 	private $base_uri;
 
-	public function __construct(array $options = []) {
+	public function __construct(string $base_uri = null)
+	{
 		$this->registry = new Registry;
 
-		$this->options = $options;
-
-
-		if (empty($this->options['base_uri']))
+		if (null === $base_uri)
 			throw new PrometheusException("Prometheus requires a base_uri option, which points to the pushgateway");
 
-		$this->base_uri = $options['base_uri'];
+		$this->base_uri = $base_uri;
 
 		// TODO: Allow option for requiring http basic authentication
 	}
 
-	public function newCounter(array $opts = []) {
+	public function newCounter(array $opts = []) : Counter
+	{
 		return $this->register(new Counter($opts));
 	}
 
-	public function newGauge(array $opts = []) {
+	public function newGauge(array $opts = []) : Gauge
+	{
 		return $this->register(new Gauge($opts));
 	}
 
-	public function newHistogram(array $opts = []) {
+	public function newHistogram(array $opts = []) : Histogram
+	{
 		return $this->register(new Histogram($opts));
 	}
 
-	private function register(Metric $metric) {
+	private function register(Metric $metric) : Metric
+	{
 		return $this->registry->register($metric);
 	}
 
-	public function serialize() {
+	public function getMetric($metric) : ?Metric
+	{
+		return $this->registry->getMetric($metric);
+	}
+
+	public function serialize() : string
+	{
 
 		$body = "";
 
@@ -48,27 +57,29 @@ class Client {
 	}
 
 
-	function pushMetrics($job=Null, $instance=Null)
+	function pushMetrics(string $job = null, string $instance = null)
 	{
 		$url = $this->base_uri;
 
-		if($instance && !$job) throw new PrometheusException("Instance passed but job was set to null.  Job must be set to a non empty string.");
-		if(!is_null($job) && $job == "" ) throw new PrometheusException("Job was set to an empty string.  Job must be set to a non empty string.");
-		elseif(!is_null($instance) && $instance == "" ) throw new PrometheusException("Instance was set to an empty string.  If Instance is set it must be a non empty string.");
+		if ($instance && !$job) throw new PrometheusException("Instance passed but job was set to null.  Job must be set to a non empty string.");
+		if (!is_null($job) && $job == "") throw new PrometheusException("Job was set to an empty string.  Job must be set to a non empty string.");
+		elseif (!is_null($instance) && $instance == "") throw new PrometheusException("Instance was set to an empty string.  If Instance is set it must be a non empty string.");
 
-		if($job) $url.=$job;
-		if($instance) $url.="/instance/".$instance;
+		if ($job) $url .= $job;
+		if ($instance) $url .= "/instance/" . $instance;
 
 		$ch = \curl_init($url);
 
-		\curl_setopt( $ch, CURLOPT_RETURNTRANSFER, TRUE );
-		\curl_setopt( $ch, CURLOPT_CUSTOMREQUEST, "PUT" );
-		\curl_setopt( $ch, CURLOPT_TIMEOUT, 1 );
-		\curl_setopt( $ch, CURLOPT_POSTFIELDS, $this->serialize() );
+		\curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+		\curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "PUT");
+		\curl_setopt($ch, CURLOPT_TIMEOUT, 1);
+		\curl_setopt($ch, CURLOPT_POSTFIELDS, $this->serialize());
 
-		if (\curl_exec( $ch ) === false) {
+		if (\curl_exec($ch) === false) {
 			throw new PrometheusException("Error sending metrics to push gateway: " . \curl_error($ch));
 		}
+
+		$this->registry->cleanup();
 
 		#TODO: Can the pushgateway return a 200 on successful PUT?
 		# Currently it returns nothing no matter what, lame

--- a/src/Counter.php
+++ b/src/Counter.php
@@ -2,29 +2,37 @@
 
 namespace Prometheus;
 
-class Counter extends Metric {
-	public function __construct(array $opts = []) {
+class Counter extends Metric
+{
+	public function __construct(array $opts = [])
+	{
 		parent::__construct($opts);
 	}
 
-	public function type() {
+	public function type() : string
+	{
 		return "counter";
 	}
 
-	public function defaultValue() {
+	public function defaultValue() : int
+	{
 		return 0;
 	}
 
-	public function increment(array $labels = [], $by = 1) {
+	public function increment(array $labels = [], $by = 1) : int
+	{
 		$hash = $this->hashLabels($labels);
 
 		if (!isset($this->values[$hash]))
 			$this->values[$hash] = $this->defaultValue();
 
 		$this->values[$hash] += $by;
+
+		return $this->values[$hash];
 	}
 
-	public function decrement(array $labels = [], $by = 1) {
+	public function decrement(array $labels = [], $by = 1) : int
+	{
 		$this->increment($labels, -1 * $by);
 	}
 }

--- a/src/Gauge.php
+++ b/src/Gauge.php
@@ -2,24 +2,31 @@
 
 namespace Prometheus;
 
-class Gauge extends Metric {
-	public function __construct(array $opts = []) {
+class Gauge extends Metric
+{
+	public function __construct(array $opts = [])
+	{
 		parent::__construct($opts);
 	}
 
-	public function type() {
+	public function type() : string
+	{
 		return "gauge";
 	}
 
-	public function defaultValue() {
+	public function defaultValue() : int
+	{
 		return 0;
 	}
 
-	public function set(array $labels, $val) {
+	public function set(array $labels, float $val) : self
+	{
 		$hash = $this->hashLabels($labels);
 		if (!isset($this->values[$hash]))
 			$this->values[$hash] = $this->defaultValue();
 
 		$this->values[$hash] = $val;
+
+		return $this;
 	}
 }

--- a/src/Histogram.php
+++ b/src/Histogram.php
@@ -2,61 +2,64 @@
 
 namespace Prometheus;
 
-class Histogram extends Metric {
-    public function __construct(array $opts = []) {
-        parent::__construct($opts);
-        $this->buckets = isset($opts['buckets']) ? $opts['buckets'] : [1,2,3];
-    }
-    
-    public function type() {
-        return "histogram";
-    }
+class Histogram extends Metric
+{
+	public function __construct(array $opts = [])
+	{
+		parent::__construct($opts);
+		$this->buckets = isset($opts['buckets']) ? $opts['buckets'] : [1, 2, 3];
+	}
 
-    public function defaultValue() {
-        return 0;
-    }
+	public function type() : string
+	{
+		return "histogram";
+	}
 
-    public function getBuckets(){
-        return $this->buckets;
-    }
+	public function defaultValue() : int
+	{
+		return 0;
+	}
 
-    public function observe(array $labels, $value) {
+	public function getBuckets() : array
+	{
+		return $this->buckets;
+	}
 
-        $labels["__suffix"] = "_bucket";
-        foreach ($this->buckets as $bucket) {
-            $labels["le"] = $bucket;
-            $hash = $this->hashLabels($labels);
-            if (!isset($this->values[$hash])) {
-                $this->values[$hash] = $this->defaultValue();
-            }
-            if ($value <= $bucket) {
-                $this->values[$hash] += 1;
-            }
-        }
-        $labels["le"] = '+Inf';
-        $hash = $this->hashLabels($labels);
-        if (!isset($this->values[$hash])) {
-            $this->values[$hash] = $this->defaultValue();
-        }
-        $this->values[$hash] += 1;
-        unset($labels["le"]);
-
-
-        $labels["__suffix"] = "_count";
-        $hash = $this->hashLabels($labels);
-        if (!isset($this->values[$hash])) {
-            $this->values[$hash] = $this->defaultValue();
-        }
-        $this->values[$hash] += 1;
+	public function observe(array $labels, float $value) : void
+	{
+		$labels["__suffix"] = "_bucket";
+		foreach ($this->buckets as $bucket) {
+			$labels["le"] = $bucket;
+			$hash         = $this->hashLabels($labels);
+			if (!isset($this->values[$hash])) {
+				$this->values[$hash] = $this->defaultValue();
+			}
+			if ($value <= $bucket) {
+				$this->values[$hash] += 1;
+			}
+		}
+		$labels["le"] = '+Inf';
+		$hash         = $this->hashLabels($labels);
+		if (!isset($this->values[$hash])) {
+			$this->values[$hash] = $this->defaultValue();
+		}
+		$this->values[$hash] += 1;
+		unset($labels["le"]);
 
 
-        $labels["__suffix"] = "_sum";
-        $hash = $this->hashLabels($labels);
-        if (!isset($this->values[$hash])) {
-            $this->values[$hash] = $this->defaultValue();
-        }
-        $this->values[$hash] += $value;
+		$labels["__suffix"] = "_count";
+		$hash               = $this->hashLabels($labels);
+		if (!isset($this->values[$hash])) {
+			$this->values[$hash] = $this->defaultValue();
+		}
+		$this->values[$hash] += 1;
 
 
-    }
+		$labels["__suffix"] = "_sum";
+		$hash               = $this->hashLabels($labels);
+		if (!isset($this->values[$hash])) {
+			$this->values[$hash] = $this->defaultValue();
+		}
+		$this->values[$hash] += $value;
+	}
 }

--- a/src/PrometheusException.php
+++ b/src/PrometheusException.php
@@ -2,6 +2,7 @@
 
 namespace Prometheus;
 
-class PrometheusException extends \Exception {
-	
+class PrometheusException extends \Exception
+{
+
 }

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -1,11 +1,14 @@
 <?php
+
 namespace Prometheus;
 
 
-class Registry {
+class Registry
+{
 	private $metrics = [];
 
-	public function register(Metric $metric) {
+	public function register(Metric $metric)
+	{
 		$name = $metric->full_name;
 
 		if (isset($this->metrics[$name])) {
@@ -17,7 +20,18 @@ class Registry {
 		return $metric;
 	}
 
-	public function getMetrics() {
+	public function cleanup()
+	{
+		$this->metrics = [];
+	}
+
+	public function getMetric($metric) : ?Metric
+	{
+		return $this->metrics[$metric] ?? null;
+	}
+
+	public function getMetrics() : array
+	{
 		return $this->metrics;
 	}
 }

--- a/test/counter_test.php
+++ b/test/counter_test.php
@@ -3,26 +3,25 @@
 require_once dirname(__FILE__) . '/../vendor/autoload.php';
 
 
-$client = new Prometheus\Client([
-	'base_uri' => 'http://localhost:9091/metrics/job/',
-]);
+$client = new Prometheus\Client('http://localhost:9091/metrics/job/');
 
-$counter = $client->newCounter([
-	'namespace' => 'php_client',
-	'subsystem' => 'testing',
-	'name' => 'counter',
-	'help' => 'Testing the PHPClients Counter',
-]);
+$counter = $client->newCounter(
+	[
+		'namespace' => 'php_client',
+		'subsystem' => 'testing',
+		'name'      => 'counter',
+		'help'      => 'Testing the PHPClients Counter',
+	]
+);
 
 $job_id = uniqid();
-while(true)
-{
-	$counter->increment( [ 'url' => 'home.php', 'status_code' => 200 ], rand( 1, 50 ) );
-	$counter->increment( [ 'url' => 'home.php', 'status_code' => 404 ], rand( 1, 50 ) );
-	
-	$client->pushMetrics( "pretend_server", $job_id );
+while (true) {
+	$counter->increment(['url' => 'home.php', 'status_code' => 200], rand(1, 50));
+	$counter->increment(['url' => 'home.php', 'status_code' => 404], rand(1, 50));
 
-	$sleepTime = rand( 1, 20 );
+	$client->pushMetrics("pretend_server", $job_id);
+
+	$sleepTime = rand(1, 20);
 	echo "sleeping $sleepTime\n";
-	sleep( $sleepTime );
+	sleep($sleepTime);
 }

--- a/test/guage_test.php
+++ b/test/guage_test.php
@@ -3,27 +3,26 @@
 require_once dirname(__FILE__) . '/../vendor/autoload.php';
 
 
-$client = new Prometheus\Client([
-	'base_uri' => 'http://localhost:9091/metrics/job/',
-]);
+$client = new Prometheus\Client('http://localhost:9091/metrics/job/');
 
-$guage = $client->newGauge([
-	'namespace' => 'php_client',
-	'subsystem' => 'testing',
-	'name' => 'Guage',
-	'help' => 'Testing the PHPClients guage',
-]);
+$guage = $client->newGauge(
+	[
+		'namespace' => 'php_client',
+		'subsystem' => 'testing',
+		'name'      => 'Guage',
+		'help'      => 'Testing the PHPClients guage',
+	]
+);
 
 $job_id = uniqid();
-while(true)
-{
-	$guage->set( [ 'key1' => 'val1' ], rand( 1, 50 ) );
-	$guage->set( [ 'key2' => 'val2'], rand( 1, 50 ) );
+while (true) {
+	$guage->set(['key1' => 'val1'], rand(1, 50));
+	$guage->set(['key2' => 'val2'], rand(1, 50));
 
 	echo "attempting a push\n";
-	$client->pushMetrics( "pretend_server", $job_id );
+	$client->pushMetrics("pretend_server", $job_id);
 	echo "push done\n";
-	$sleepTime = rand( 1, 5 );
+	$sleepTime = rand(1, 5);
 	echo "sleeping $sleepTime\n";
-	sleep( $sleepTime );
+	sleep($sleepTime);
 }

--- a/test/histogram_test.php
+++ b/test/histogram_test.php
@@ -3,23 +3,23 @@
 require_once dirname(__FILE__) . '/../vendor/autoload.php';
 
 
-$client = new Prometheus\Client([
-	'base_uri' => 'http://localhost:9091/metrics/job/',
-]);
+$client = new Prometheus\Client('http://localhost:9091/metrics/job/');
 
-$histogram = $client->newHistogram([
-	'namespace' => 'meta_data',
-	'subsystem' => 'tv',
-	'name' => 'elements_per_hit',
-	'help' => 'Testing the PHPClients Histogram',
-	'buckets' => [10, 25, 50, 75, 100]
-]);
+$histogram = $client->newHistogram(
+	[
+		'namespace' => 'meta_data',
+		'subsystem' => 'tv',
+		'name'      => 'elements_per_hit',
+		'help'      => 'Testing the PHPClients Histogram',
+		'buckets'   => [10, 25, 50, 75, 100],
+	]
+);
 
-while(true){
-	$histogram->observe(['domain'=>'hulu'], rand(0,100));
-	$histogram->observe(['domain'=>'crunchyroll'], rand(0,100));
+while (true) {
+	$histogram->observe(['domain' => 'hulu'], rand(0, 100));
+	$histogram->observe(['domain' => 'crunchyroll'], rand(0, 100));
 
-	$client->pushMetrics( "foreign_language", "test_server_0");
+	$client->pushMetrics("foreign_language", "test_server_0");
 
 	echo "sleeping 5\n";
 	sleep(5);


### PR DESCRIPTION
I wanted to use this lib and had some small troubles (point 3) which resulted in a more major cleanup.

changing `Prometheus\Client` constructor is a breaking change so, if this gets merged, it should result in a major version bump

1. move to php 7.1
2. major cleanup
3. clean metrics after they were pushed to the server to add new metrics with the same name later on